### PR TITLE
DomainSeeker_CLI: argparse and change to get_fitted_domain.py

### DIFF
--- a/DomainSeeker_CLI/calculate_posterior_probabilities.py
+++ b/DomainSeeker_CLI/calculate_posterior_probabilities.py
@@ -1,6 +1,6 @@
+import os,sys,argparse
 import numpy as np
 import MDAnalysis as mda
-import os,sys
 import matplotlib.pyplot as plt
 import networkx as nx
 from scipy.spatial.transform import Rotation
@@ -13,16 +13,28 @@ import warnings
 
 
 project_dir="."
-origin_domain_dir=sys.argv[1]
-map_dir=sys.argv[2]
-map_level=float(sys.argv[3])
-fitout_dir=sys.argv[4]
 
-acceptor_prior_probability_cutoff=float(sys.argv[5])
-donor_prior_probability_cutoff=float(sys.argv[6])
-evidence_strength=float(sys.argv[7])
+parser = argparse.ArgumentParser(description="Integrate extra experimental data")
+parser.add_argument("origin_domain_dir")
+parser.add_argument("map_dir")
+parser.add_argument("map_level",help="The threshold value of the density map, used to determine whether two densities are adjacent")
+parser.add_argument("fitout_dir")
+parser.add_argument("acceptor_prior_probability_cutoff", help="These dual thresholds control which states participate in posterior calculations to reduce computational cost while preserving accuracy. States with prior probabilities exceeding the donor_cutoff may influence other densities, while those above the acceptor_cutoff may be influenced by external evidence. Only states meeting either threshold are included in the calculation")
+parser.add_argument("donor_prior_probability_cutoff",help="These dual thresholds control which states participate in posterior calculations to reduce computational cost while preserving accuracy. States with prior probabilities exceeding the donor_cutoff may influence other densities, while those above the acceptor_cutoff may be influenced by external evidence. Only states meeting either threshold are included in the calculation")
+parser.add_argument("evidence_strength",help="The strength of evidence provided by the cross-linking data. A higher value increases the impact of the cross-linking data on the final results.")
+parser.add_argument("crosslink_files",nargs="+")
+argument=parser.parse_args()
 
-crosslink_files = sys.argv[8:]
+origin_domain_dir=argument.origin_domain_dir
+map_dir=argument.map_dir
+map_level=float(argument.map_level)
+fitout_dir=argument.fitout_dir
+
+acceptor_prior_probability_cutoff=float(argument.acceptor_prior_probability_cutoff)
+donor_prior_probability_cutoff=float(argument.donor_prior_probability_cutoff)
+evidence_strength=float(argument.evidence_strength)
+
+crosslink_files=argument.crosslink_files
 
 
 def read_prior_probabilities(file_path):

--- a/DomainSeeker_CLI/calculate_prior_probabilities.py
+++ b/DomainSeeker_CLI/calculate_prior_probabilities.py
@@ -1,16 +1,26 @@
-import os, sys
+import os, sys, argparse
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 import math
 from scipy.interpolate import interp1d
 
-map_dir = sys.argv[1]
-fitout_dir = sys.argv[2]
-box_num = int(sys.argv[3])
-min_entries_per_box = int(sys.argv[4])
-relative_density_cutoff = float(sys.argv[5])
-z_score_offset = float(sys.argv[6])
+parser = argparse.ArgumentParser(description="Calculate prior probability of each fitted domain",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("map_dir")
+parser.add_argument("fitout_dir")
+parser.add_argument("--box_num", default=5, help="When calculating z-scores, data points are partitioned into a grid of box_num² cells based on their overlap volume and correlation values")
+parser.add_argument("--min_entries_per_box", default=200, help="After filtering cells by relative density, cells within the same overlap volume range are grouped into box_num bins. Each bin must contain at least min_data_per_box data points; otherwise, it is merged with an adjacent bin. The mean and standard deviation of the correlation values are computed for each bin to derive an interpolation function across overlap volumes")
+parser.add_argument("--relative_density_cutoff", default=1, help="Relative density is defined as the ratio of the number of data points in a grid cell to the average number of data points across all cells. Only cells with a relative density above this threshold are used when calculating the average curve, to minimize the influence of anomalies")
+parser.add_argument("--z_score_offset", default=30, help="The z-score is converted to a probability using a sigmoid function: Sigmoid(zScore - offset)")
+argument = parser.parse_args()
+
+map_dir = argument.map_dir
+fitout_dir = argument.fitout_dir
+box_num = int(argument.box_num)
+min_entries_per_box = int(argument.min_entries_per_box)
+relative_density_cutoff = float(argument.relative_density_cutoff)
+z_score_offset = float(argument.z_score_offset)
 
 grids_x=box_num
 grids_y=box_num

--- a/DomainSeeker_CLI/fetch_pdb_pae.py
+++ b/DomainSeeker_CLI/fetch_pdb_pae.py
@@ -1,24 +1,21 @@
-import os,sys
+import os,sys,argparse
 import wget
 import numpy as np
 from tqdm import tqdm
 
-UniprotID_list_path=sys.argv[1]
-output_pdb_dir=sys.argv[2]
-output_pae_dir=sys.argv[3]
 
+parser = argparse.ArgumentParser(description="Fetch pdb and pae files from AFDB")
+parser.add_argument("uniprot_list", help="Text file with one UniProt IDs per line")
+parser.add_argument("pdb_dir", help="PDB files will be saved here")
+parser.add_argument("pae_dir", help="PAE files will be saved here")
+argument = parser.parse_args()
 
-
-os.makedirs(output_pdb_dir,exist_ok=True)
-missing_pdbs=[]
-
-os.makedirs(output_pae_dir,exist_ok=True)
-missing_paes=[]
-
+UniprotID_list_path=argument.uniprot_list
+output_pdb_dir=argument.pdb_dir
+output_pae_dir=argument.pae_dir
 
 os.makedirs(output_pdb_dir,exist_ok=True)
 missing_pdbs=[]
-
 
 os.makedirs(output_pae_dir,exist_ok=True)
 missing_paes=[]

--- a/DomainSeeker_CLI/fit_chimerax_directly.py
+++ b/DomainSeeker_CLI/fit_chimerax_directly.py
@@ -1,0 +1,35 @@
+from chimerax.core.session import Session
+from chimerax.core import core_settings
+from chimerax.core.session import register_misc_commands
+from chimerax.core import attributes
+from chimerax.core.commands import run
+from chimerax.core import startup
+from chimerax.core import toolshed
+from chimerax.core import version
+from chimerax.core.__main__ import _set_app_dirs, dedup_sys_path
+from chimerax.core import tools
+from chimerax.core import undo
+
+dedup_sys_path()
+_set_app_dirs(version)
+sess = Session(silent=True)
+core_settings.init(sess)
+register_misc_commands(sess)
+attributes.RegAttrManager(sess)
+from chimerax.core.nogui import NoGuiLog
+sess.logger.add_log(NoGuiLog())
+startup.run_user_startup_scripts(sess)
+toolshed.init(
+        sess.logger,
+        debug=sess.debug,
+        check_available=False,
+        remote_url=None,
+        session=sess
+    )
+sess.toolshed = toolshed.get_toolshed()
+sess.toolshed.bootstrap_bundles(sess, False)
+sess.tools = tools.Tools(sess, first=True)
+sess.undo = undo.Undo(sess, first=True)
+run(sess, 'open /home/ek/code/DomainSeeker/Example/em_data/A.mrc')
+run(sess, 'open /home/ek/code/DomainSeeker/Example/pdb/Q6X6Z7.pdb')
+run(sess, 'fitmap #2 inmap #1 resolution 6.5 search 200')

--- a/DomainSeeker_CLI/fit_chimerax_directly.py
+++ b/DomainSeeker_CLI/fit_chimerax_directly.py
@@ -1,35 +1,140 @@
-from chimerax.core.session import Session
-from chimerax.core import core_settings
-from chimerax.core.session import register_misc_commands
-from chimerax.core import attributes
-from chimerax.core.commands import run
-from chimerax.core import startup
-from chimerax.core import toolshed
-from chimerax.core import version
-from chimerax.core.__main__ import _set_app_dirs, dedup_sys_path
-from chimerax.core import tools
-from chimerax.core import undo
+#!/usr/lib/ucsf-chimerax-daily/bin/python3.9
 
-dedup_sys_path()
-_set_app_dirs(version)
-sess = Session(silent=True)
-core_settings.init(sess)
-register_misc_commands(sess)
-attributes.RegAttrManager(sess)
-from chimerax.core.nogui import NoGuiLog
-sess.logger.add_log(NoGuiLog())
-startup.run_user_startup_scripts(sess)
-toolshed.init(
-        sess.logger,
-        debug=sess.debug,
-        check_available=False,
-        remote_url=None,
-        session=sess
-    )
-sess.toolshed = toolshed.get_toolshed()
-sess.toolshed.bootstrap_bundles(sess, False)
-sess.tools = tools.Tools(sess, first=True)
-sess.undo = undo.Undo(sess, first=True)
-run(sess, 'open /home/ek/code/DomainSeeker/Example/em_data/A.mrc')
-run(sess, 'open /home/ek/code/DomainSeeker/Example/pdb/Q6X6Z7.pdb')
-run(sess, 'fitmap #2 inmap #1 resolution 6.5 search 200')
+import os, argparse
+import numpy as np
+
+import chimerax
+from chimerax.core.session import Session, register_misc_commands
+from chimerax.core import core_settings, attributes, startup, toolshed, version, tools, undo
+from chimerax.core.commands import run
+
+def parser() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('map_path')
+    parser.add_argument('output_subdir')
+    parser.add_argument('ref_map_threshold')
+    parser.add_argument('resolution')
+    parser.add_argument('n_search')
+    parser.add_argument('domain_path', nargs="+")
+    return parser.parse_args()
+
+
+# domain_path=sys.argv[1]
+# map_path=sys.argv[2]
+# output_subdir=sys.argv[3]
+# ref_map_threshold=float(sys.argv[4])
+# resolution=float(sys.argv[5])
+# n_search=int(sys.argv[6])
+
+
+def session_setup() -> Session:
+    from chimerax.core import version
+    if version == '1.6.dev202302040126':
+        import appdirs
+        chimerax.app_dirs = ad = appdirs.AppDirs("ChimeraX", appauthor="",
+                                                version="")
+        chimerax.app_dirs_unversioned = adu = appdirs.AppDirs("ChimeraX", appauthor="")
+        rootdir = "/"
+        chimerax.app_bin_dir = os.path.join(rootdir, "bin")
+        chimerax.app_data_dir = os.path.join(rootdir, "share")
+        chimerax.app_lib_dir = os.path.join(rootdir, "lib")
+        sess = Session("ChimeraX", silent=True)
+        core_settings.init(sess)
+        register_misc_commands(sess)
+        attributes.RegAttrManager(sess)
+        from chimerax.core.nogui import NoGuiLog
+        sess.logger.add_log(NoGuiLog())
+        startup.run_user_startup_scripts(sess)
+        toolshed.init(
+                sess.logger,
+                debug=sess.debug,
+                check_available=False,
+                remote_url=None,
+                session=sess
+            )
+        sess.toolshed = toolshed.get_toolshed()
+        sess.toolshed.bootstrap_bundles(sess, False)
+        sess.tools = tools.Tools(sess, first=True)
+        sess.undo = undo.Undo(sess, first=True)
+        return sess
+    else:
+        from chimerax.core.__main__ import _set_app_dirs, dedup_sys_path
+        dedup_sys_path()
+        _set_app_dirs(version)
+        sess = Session(silent=True)
+        core_settings.init(sess)
+        register_misc_commands(sess)
+        attributes.RegAttrManager(sess)
+        from chimerax.core.nogui import NoGuiLog
+        sess.logger.add_log(NoGuiLog())
+        startup.run_user_startup_scripts(sess)
+        toolshed.init(
+                sess.logger,
+                debug=sess.debug,
+                check_available=False,
+                remote_url=None,
+                session=sess
+            )
+        sess.toolshed = toolshed.get_toolshed()
+        sess.toolshed.bootstrap_bundles(sess, False)
+        sess.tools = tools.Tools(sess, first=True)
+        sess.undo = undo.Undo(sess, first=True)
+
+        return sess
+
+
+
+def fit_single_structure(session: Session, domain_path: str, output_subdir: str, ref_map_threshold: float, resolution: float, n_search: int):
+    '''
+    map has to be preloaded into session before passing session to fit_single_structure
+    '''
+    run(session,f'open {domain_path}')
+    fits=run(session,f"fitmap #3 inmap #2 resolution {resolution} search {n_search}")
+    # run(sess, 'open /home/ek/code/DomainSeeker/Example/em_data/A.mrc')
+    # run(session, 'open /cds/ban/ekummerant/domainseeker/DomainSeeker/Example/em_data/A.mrc')
+    # run(sess, 'open /home/ek/code/DomainSeeker/Example/pdb/Q6X6Z7.pdb')
+    # run(session, "open /cds/ban/ekummerant/domainseeker/DomainSeeker/DomainSeeker_CLI/test/domains/A0A1Y7VMI0_D0.pdb")
+    # fits = run(sess, 'fitmap #2 inmap #1 resolution 6.5 search 200')
+    log_data=[]
+    for fit in fits:
+        transform_string_list=[]
+        for element in fit.model_transforms()[0][1].matrix.reshape(-1):
+            transform_string_list.append(f"{element:10.5f}")
+        if fit.correlation() >= 0.00001:
+            log_data.append([f"{fit.correlation():8.5f}",f"{fit.hits():8d}"]+transform_string_list)
+
+    # write transformation info into log
+    print(len(log_data))
+    if len(log_data) >=1:
+        os.makedirs(output_subdir,exist_ok=True)
+        fitlog_subdir=os.path.join(output_subdir,"fitlogs")
+        os.makedirs(fitlog_subdir,exist_ok=True)
+        log_path=os.path.join(fitlog_subdir,os.path.basename(domain_path).replace('pdb','log'))
+        print(f"{output_subdir=}")
+        print(f"{log_path=}")
+        np.savetxt(log_path,log_data,fmt="%s")
+    
+    run(session,f'close ~#1,2')
+
+
+
+def main():
+    argument = parser()
+
+    sess = session_setup()
+    run(sess,f'open {argument.map_path}')
+    run(sess,f"volume threshold #1 minimum {float(argument.ref_map_threshold)} set 0")
+    run(sess,f'volume #2 level {float(argument.ref_map_threshold)}')
+
+    for domain in argument.domain_path:
+        fit_single_structure(
+            sess,
+            domain,
+            argument.output_subdir,
+            float(argument.ref_map_threshold),
+            float(argument.resolution),
+            int(argument.n_search)
+        )
+
+if __name__ == "__main__":
+    main()

--- a/DomainSeeker_CLI/fit_with_chimerax.py
+++ b/DomainSeeker_CLI/fit_with_chimerax.py
@@ -1,4 +1,5 @@
-import os,sys,argparse,shutil
+import os,sys,shutil,argparse,math
+from dataclasses import dataclass, field
 import subprocess,multiprocessing
 import MDAnalysis as mda
 import numpy as np
@@ -11,11 +12,11 @@ script_dir=os.path.dirname(os.path.realpath(__file__)).replace("\\","/")
 
 python_exec=os.path.realpath(sys.executable)
 chimerax_dir = os.path.dirname(python_exec)
-# mac特殊处理
+# mac
 if sys.platform == 'darwin':
     chimerax_dir = chimerax_dir.replace("/Contents/bin", "/Contents/MacOS")
 
-# 不同系统的ChimeraX
+# ChimeraX
 # windows
 if sys.platform in ["win32","win64"]:
     ChimeraX=os.path.join(chimerax_dir,"ChimeraX-console.exe")
@@ -26,77 +27,46 @@ elif sys.platform=="darwin":
 else:
     ChimeraX = os.path.join(chimerax_dir,"chimerax")
 
-def fit(params):
-    domain_filename, ref_map_filename = params
-    domain_path=os.path.join(domain_dir,domain_filename).replace("\\","/")
-    map_path=os.path.join(map_dir,ref_map_filename).replace("\\","/")
-    output_subdir=os.path.join(fitout_dir,ref_map_filename).replace("\\","/")
-    cmd_list = [ChimeraX, "--nogui", "--script", f'{script_dir}/fit_in_chimerax.py {domain_path} {map_path} {output_subdir} {ref_map_threshold} {resolution} {n_search}', "--exit"]
-    # 舍弃输出
-    subprocess.run(cmd_list,shell=False,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+
     
-# 全局变量
-parser = argparse.ArgumentParser(description="Perform domain-density fitting. The EM density map must first be segmented (manually or automatically) into regions of interest, each saved as a separate .mrc file",
-                                 epilog="Use get_fitted_domains.py to obtain .pdb files of the fitted domains")
-parser.add_argument("domain_dir")
-parser.add_argument("map_dir")
-parser.add_argument("fitout_dir")
-parser.add_argument("ref_map_threshold",help="Electron density map threshold value")
-parser.add_argument("resolution",help="Resolution of the electron density map, used to generate simulated densities for individual domains")
-parser.add_argument("n_search",help="Number of initial starting positions for gradient-based correlation optimization. A value of 200 is recommended for typical domain sizes, balancing computational cost and accuracy. Larger density regions may require more starting positions for optimal fitting")
-parser.add_argument("negtive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
-parser.add_argument("positive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
-parser.add_argument("ncores",help="Number of parallel processes to use")
-parser.add_argument("--chimerax", default = False, help="Path to ChimeraX if it cannot be determined automatically")
+# 
 
-argument = parser.parse_args()
+def parser() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Perform domain-density fitting. The EM density map must first be segmented (manually or automatically) into regions of interest, each saved as a separate .mrc file",
+                                    epilog="Use get_fitted_domains.py to obtain .pdb files of the fitted domains")
+    parser.add_argument("domain_dir")
+    parser.add_argument("map_dir")
+    parser.add_argument("fitout_dir")
+    parser.add_argument("ref_map_threshold",help="Electron density map threshold value")
+    parser.add_argument("resolution",help="Resolution of the electron density map, used to generate simulated densities for individual domains")
+    parser.add_argument("n_search",help="Number of initial starting positions for gradient-based correlation optimization. A value of 200 is recommended for typical domain sizes, balancing computational cost and accuracy. Larger density regions may require more starting positions for optimal fitting")
+    parser.add_argument("negtive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
+    parser.add_argument("positive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
+    parser.add_argument("ncores",help="Number of parallel processes to use")
+    parser.add_argument("--batch-size", default = 10)
+    parser.add_argument("--chimerax", default = False, help="Path to ChimeraX if it cannot be determined automatically", required=False)
+    parser.add_argument("--calculation", choices=['default', 'chimerax-batch', 'direct-batch'])
+    parser.add_argument("--max-domain", default = -1)
 
-domain_dir = argument.domain_dir
-map_dir = argument.map_dir
-fitout_dir = argument.fitout_dir
-ref_map_threshold = float(argument.ref_map_threshold)
-resolution = float(argument.resolution)
-n_search = int(argument.n_search)
-negtive_laplacian_cutoff = float(argument.negtive_laplacian_cutoff)
-positive_laplacian_cutoff = float(argument.positive_laplacian_cutoff)
-n_process=int(argument.ncores)
-if argument.chimerax:
-    ChimeraX = argument.chimerax
-
-if shutil.which(ChimeraX) is None:
-    raise ValueError('ChimeraX not found')
-
-fit_map_laplacian_cutoff_low=-2
-fit_map_laplacian_cutoff_high=15
-
-n_process=int(sys.argv[9])
-
-## 局部打分
-def get_ref_map_mat_laplacian_and_params(ref_map_path):
-    ref_map=mrcfile.open(ref_map_path)
-    ref_map_mat=ref_map.data.T
-    ref_map_mat=ref_map_mat*(ref_map_mat>=ref_map_threshold)
-    origin=np.array(ref_map.header.origin.tolist())
-    lengths=np.array(ref_map.header.cella.tolist())
-    grid_shape=np.array([ref_map.header.nx,ref_map.header.ny,ref_map.header.nz])
-    voxel=lengths[0]/grid_shape[0]
-    density_param_dict={'origin':origin,'lengths':lengths,'grid_shape':grid_shape,'voxel':voxel}
-    ref_map_mat_laplacian=scipy.ndimage.convolve(ref_map_mat,laplacian_kernel,mode='constant')
-    return [ref_map_mat_laplacian,density_param_dict]
+    return parser.parse_args()
 
 # generate density matrix
-
-weight_dict={'C':12.011,'N':14.007,'O':16.000,'S':32.060}
+WEIGHT_DICT = {
+    'C':12.011,
+    'N':14.007,
+    'O':16.000,
+    'S':32.060
+    }
 
 # Laplacian kernel
-laplacian_kernel=np.zeros([3,3,3])
-laplacian_kernel[1,1,1]=-6
-laplacian_kernel[1,1,0]=1
-laplacian_kernel[1,1,2]=1
-laplacian_kernel[1,0,1]=1
-laplacian_kernel[1,2,1]=1
-laplacian_kernel[0,1,1]=1
-laplacian_kernel[2,1,1]=1
+LAPLACIAN_KERNEL=np.zeros([3,3,3])
+LAPLACIAN_KERNEL[1,1,1]=-6
+LAPLACIAN_KERNEL[1,1,0]=1
+LAPLACIAN_KERNEL[1,1,2]=1
+LAPLACIAN_KERNEL[1,0,1]=1
+LAPLACIAN_KERNEL[1,2,1]=1
+LAPLACIAN_KERNEL[0,1,1]=1
+LAPLACIAN_KERNEL[2,1,1]=1
 
 
 def add_atom(data,voxel,origin,xyz,weight):
@@ -133,6 +103,43 @@ def get_gaussian_kernel(resolution,voxel):
 def gaussian_filter(fit_map_mat,resolution,voxel):
     return scipy.ndimage.convolve(fit_map_mat,get_gaussian_kernel(resolution,voxel),mode='constant')
 
+def fit(
+        ref_map_filename: str,
+        map_dir: str,
+        domain_dir: str,
+        fitout_dir: str,
+        ref_map_threshold: float,
+        resolution: float,
+        n_search: int,
+        domain_filename_list: list[str]
+):
+    map_path=os.path.join(map_dir,ref_map_filename).replace("\\","/")
+    output_subdir=os.path.join(fitout_dir,ref_map_filename).replace("\\","/")
+    domain_filename_list = [os.path.join(domain_dir,domain_filename).replace("\\","/") for domain_filename in domain_filename_list]
+
+    # Default command
+    # cmd_list = [ChimeraX, "--nogui", "--script", f"{script_dir}/fit_in_chimerax.py {domain_path} {map_path} {output_subdir} {ref_map_threshold} {resolution} {n_search}", "--exit"]
+    # subprocess.run(cmd_list,shell=False,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+
+    # Use ChimeraX, but keep session open for batch
+    # cmd_list = [ChimeraX, "--nogui", "--script", f"{script_dir}/fit_in_chimerax_pac.py {map_path} {output_subdir} {ref_map_threshold} {resolution} {n_search} {" ".join(domain_filename_list)}", "--exit"]
+    # subprocess.run(cmd_list,shell=False,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+
+    # Use ChimeraX in python script directly
+    cmd_list = [
+            '/usr/lib/ucsf-chimerax-daily/bin/python3.9', 
+            '/cds/ban/ekummerant/domainseeker/DomainSeeker/DomainSeeker_CLI/fit_chimerax_directly.py', 
+            map_path, output_subdir, 
+            str(ref_map_threshold), 
+            str(resolution), 
+            str(n_search)
+        ]
+    [cmd_list.append(domain_path) for domain_path in domain_filename_list]
+    subprocess.run(cmd_list,shell=False, stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+
+def fitMultiProc(params):
+    fit(*params)
+
 # calculate scores
 
 def get_transformation_matrix_list(log_path):
@@ -145,7 +152,24 @@ def transform_positions(xyzs,transformation_matrix):
     translation_vector=transformation_matrix[:,-1]
     return xyzs.dot(rotation_matrix.T)+translation_vector
 
-def get_fit_map_mat(u,transformation_matrix,density_param_dict):
+def get_ref_map_mat_laplacian_and_params(ref_map_path, ref_map_threshold):
+    ref_map=mrcfile.open(ref_map_path)
+    ref_map_mat=ref_map.data.T
+    ref_map_mat=ref_map_mat*(ref_map_mat>=ref_map_threshold)
+    origin=np.array(ref_map.header.origin.tolist())
+    lengths=np.array(ref_map.header.cella.tolist())
+    grid_shape=np.array([ref_map.header.nx,ref_map.header.ny,ref_map.header.nz])
+    voxel=lengths[0]/grid_shape[0]
+    density_param_dict={'origin':origin,'lengths':lengths,'grid_shape':grid_shape,'voxel':voxel}
+    ref_map_mat_laplacian=scipy.ndimage.convolve(ref_map_mat,LAPLACIAN_KERNEL,mode='constant')
+    return [ref_map_mat_laplacian,density_param_dict]
+
+def get_fit_map_mat(
+        u,
+        transformation_matrix,
+        density_param_dict,
+        resolution
+    ):
     grid_shape=density_param_dict['grid_shape']
     origin=density_param_dict['origin']
     lengths=density_param_dict['lengths']
@@ -154,7 +178,7 @@ def get_fit_map_mat(u,transformation_matrix,density_param_dict):
     n_atoms=u.atoms.n_atoms
     # apply the transformation matrix
     transformed_xyzs=transform_positions(xyzs,transformation_matrix)
-    weights=[weight_dict[e] for e in u.atoms.types]
+    weights=[WEIGHT_DICT[e] for e in u.atoms.types]
     data=np.zeros(grid_shape)
     for i in range(n_atoms):
         xyz=transformed_xyzs[i]
@@ -164,9 +188,19 @@ def get_fit_map_mat(u,transformation_matrix,density_param_dict):
     data=scipy.ndimage.convolve(data,get_gaussian_kernel(resolution,voxel),mode='constant')
     return data
 
-def get_scores_overlap(u,transformation_matrix,ref_map_mat_laplacian,density_param_dict):
-    fit_map_mat=get_fit_map_mat(u,transformation_matrix,density_param_dict)
-    fit_map_mat_laplacian=scipy.ndimage.convolve(fit_map_mat,laplacian_kernel,mode='constant')
+def get_scores_overlap(
+        u,
+        transformation_matrix,
+        ref_map_mat_laplacian,
+        density_param_dict,
+        negtive_laplacian_cutoff,
+        positive_laplacian_cutoff,
+        fit_map_laplacian_cutoff_low,
+        fit_map_laplacian_cutoff_high,
+        resolution
+    ):
+    fit_map_mat=get_fit_map_mat(u,transformation_matrix,density_param_dict,resolution)
+    fit_map_mat_laplacian=scipy.ndimage.convolve(fit_map_mat,LAPLACIAN_KERNEL,mode='constant')
     sel=(ref_map_mat_laplacian<negtive_laplacian_cutoff)*(fit_map_mat_laplacian<fit_map_laplacian_cutoff_low)
     sel_ref=(ref_map_mat_laplacian<negtive_laplacian_cutoff)+(ref_map_mat_laplacian>positive_laplacian_cutoff)
     sel_fit=(fit_map_mat_laplacian<fit_map_laplacian_cutoff_low)+(fit_map_mat_laplacian>fit_map_laplacian_cutoff_high)
@@ -178,30 +212,89 @@ def get_scores_overlap(u,transformation_matrix,ref_map_mat_laplacian,density_par
     return [overlap_volume,overlap_correlation]
 
 
-def score(parms):
-    density=parms[0]
-    ref_map_mat_laplacian=parms[1]
-    log=parms[2]
-    density_param_dict=parms[3]
-    domain_name=log[:-4]
+def score(
+    density,
+    ref_map_mat_laplacian,
+    log,
+    density_param_dict,
+    domain_name,
+    domain_dir,
+    fitout_dir,
+    negtive_laplacian_cutoff,
+    positive_laplacian_cutoff,
+    fit_map_laplacian_cutoff_low,
+    fit_map_laplacian_cutoff_high,
+    resolution
+):
     domain_path=os.path.join(domain_dir,domain_name+'.pdb')
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)
-        # 抑制读取pdb时的冗余警告
+        # 
         u=mda.Universe(domain_path)     # original domain
     log_path=os.path.join(fitout_dir,density,"fitlogs",log)
     transformation_matrix_list=get_transformation_matrix_list(log_path)
     score_list=[]
     for transformation_matrix in transformation_matrix_list:
-        score_list.append(get_scores_overlap(u,transformation_matrix,ref_map_mat_laplacian,density_param_dict))
-    return [log[:-4],score_list]
+        score_list.append(
+            get_scores_overlap(
+                u,
+                transformation_matrix,
+                ref_map_mat_laplacian,
+                density_param_dict,
+                negtive_laplacian_cutoff,
+                positive_laplacian_cutoff,
+                fit_map_laplacian_cutoff_low,
+                fit_map_laplacian_cutoff_high,
+                resolution
+            )
+        )
+    return [domain_name, score_list]
 
+def scoreMultiProc(params):
+    return score(*params)
+
+
+def get_batch(
+        domains: list[str], 
+        batch_size: int, 
+        n_procs: int, 
+        max_domains: int = -1
+    ):
+    '''
+    Returns batches of size batch_size, except if there are fewer domains
+    available than are needed to fill all available processors. In that case,
+    the batch_size is reduced to fill all processors
+    '''
+    if max_domains != -1:
+        domains = domains[:max_domains]
+    if len(domains) < (batch_size * n_procs):
+        print('condition true')
+        batch_size = math.ceil(len(domains)/n_procs)
+    for i in range(0, len(domains), batch_size):
+        yield domains[i:(i+batch_size)]
 
 if __name__=="__main__":
-    os.makedirs(fitout_dir,exist_ok=True)
+    argument = parser()
 
+    domain_dir = argument.domain_dir
+    map_dir = argument.map_dir
+    fitout_dir = argument.fitout_dir
+    ref_map_threshold = float(argument.ref_map_threshold)
+    resolution = float(argument.resolution)
+    n_search = int(argument.n_search)
+    negtive_laplacian_cutoff = float(argument.negtive_laplacian_cutoff)
+    positive_laplacian_cutoff = float(argument.positive_laplacian_cutoff)
+    n_process=int(argument.ncores)
+    if argument.chimerax:
+        ChimeraX = argument.chimerax
+
+    fit_map_laplacian_cutoff_low=-2
+    fit_map_laplacian_cutoff_high=15
+
+    os.makedirs(fitout_dir,exist_ok=True)
     map_list=[file_name for file_name in os.listdir(map_dir) if file_name.endswith(".mrc")]
     domain_list=[file_name for file_name in os.listdir(domain_dir) if file_name.endswith(".pdb")]
+
 
     for i, ref_map_filename in enumerate(map_list):
         # fit
@@ -209,6 +302,14 @@ if __name__=="__main__":
         os.makedirs(output_subdir,exist_ok=True)
         fitlog_subdir=os.path.join(output_subdir,"fitlogs")
         os.makedirs(fitlog_subdir,exist_ok=True)
+
+        seen_domains = [x.removesuffix('.log') for x in os.listdir(fitlog_subdir) if os.path.isfile(os.path.join(fitlog_subdir, x)) and x.endswith('.log')]
+        filtered_domain_list = [x for x in domain_list if x.removesuffix('.pdb') not in seen_domains]
+
+        print(f'Total number of domains: {len(domain_list)}')
+        print(f'Number of domains seen: {len(seen_domains)} for map {ref_map_filename}')
+        print(f'Remaining number of domains: {len(filtered_domain_list)}')
+
 
         config_log_path=os.path.join(output_subdir,"fit_config.txt").replace("\\","/")
         config_log=open(config_log_path,'w')
@@ -220,24 +321,27 @@ if __name__=="__main__":
                          f"{n_process=}")
         config_log.close()
 
-        params_list=[(domain_filename,ref_map_filename) for domain_filename in domain_list]
+        params_list=[(ref_map_filename, map_dir, domain_dir, fitout_dir, ref_map_threshold, resolution, n_search, domain_filename_batch) for domain_filename_batch in get_batch(filtered_domain_list, int(argument.batch_size), n_process, int(argument.max_domain))]
 
         with multiprocessing.Pool(n_process) as pool:
-            # 强制迭代tqdm对象，更新进度条
-            for result in tqdm(pool.imap_unordered(fit,params_list),total=len(domain_list),desc=f"{i+1}/{len(map_list)}--Fitting {ref_map_filename}",file=sys.stdout):
-                # 处理结果
+            for result in tqdm(pool.imap_unordered(fitMultiProc,
+                                                   params_list),
+                               total=math.ceil(len(filtered_domain_list)/int(argument.batch_size)),
+                               desc=f"{i+1}/{len(map_list)}--Fitting {ref_map_filename}",
+                               file=sys.stdout,
+                               smoothing=0.2):
                 pass
 
         # score
         ref_map_path=os.path.join(map_dir,ref_map_filename).replace("\\","/")
-        ref_map_mat_laplacian,density_param_dict=get_ref_map_mat_laplacian_and_params(ref_map_path)
+        ref_map_mat_laplacian,density_param_dict=get_ref_map_mat_laplacian_and_params(ref_map_path, ref_map_threshold)
 
         log_list=[log for log in os.listdir(fitlog_subdir) if log.endswith('.log')]
 
-        pool_params=[(ref_map_filename,ref_map_mat_laplacian,log,density_param_dict) for log in log_list]
+        pool_params=[(ref_map_filename, ref_map_mat_laplacian, log, density_param_dict, log[:-4], domain_dir, fitout_dir, negtive_laplacian_cutoff, positive_laplacian_cutoff, fit_map_laplacian_cutoff_low, fit_map_laplacian_cutoff_high, resolution) for log in log_list]
 
         pool=multiprocessing.Pool(n_process)
-        scores=list(tqdm(pool.imap_unordered(score,pool_params),total=len(log_list),desc=f"{i+1}/{len(map_list)}--Locally scoring {ref_map_filename}",file=sys.stdout)) #1.将结果存入列表。2.list强制迭代tqdm对象，更新进度条
+        scores=list(tqdm(pool.imap_unordered(scoreMultiProc,pool_params),total=len(log_list),desc=f"{i+1}/{len(map_list)}--Locally scoring {ref_map_filename}",file=sys.stdout)) #1.将结果存入列表。2.list强制迭代tqdm对象，更新进度条
         pool.close()
         pool.join()
 

--- a/DomainSeeker_CLI/fit_with_chimerax.py
+++ b/DomainSeeker_CLI/fit_with_chimerax.py
@@ -1,4 +1,4 @@
-import os,sys
+import os,sys,argparse,shutil
 import subprocess,multiprocessing
 import MDAnalysis as mda
 import numpy as np
@@ -36,15 +36,36 @@ def fit(params):
     subprocess.run(cmd_list,shell=False,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
     
 # 全局变量
-domain_dir=os.path.realpath(sys.argv[1]).replace("\\","/")
-map_dir=os.path.realpath(sys.argv[2]).replace("\\","/")
-fitout_dir=os.path.realpath(sys.argv[3]).replace("\\","/")
-ref_map_threshold=float(sys.argv[4])
-resolution=float(sys.argv[5])
-n_search=int(sys.argv[6])
+parser = argparse.ArgumentParser(description="Perform domain-density fitting. The EM density map must first be segmented (manually or automatically) into regions of interest, each saved as a separate .mrc file",
+                                 epilog="Use get_fitted_domains.py to obtain .pdb files of the fitted domains")
+parser.add_argument("domain_dir")
+parser.add_argument("map_dir")
+parser.add_argument("fitout_dir")
+parser.add_argument("ref_map_threshold",help="Electron density map threshold value")
+parser.add_argument("resolution",help="Resolution of the electron density map, used to generate simulated densities for individual domains")
+parser.add_argument("n_search",help="Number of initial starting positions for gradient-based correlation optimization. A value of 200 is recommended for typical domain sizes, balancing computational cost and accuracy. Larger density regions may require more starting positions for optimal fitting")
+parser.add_argument("negtive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
+parser.add_argument("positive_laplacian_cutoff",help="Parameters for evaluating overlap region matching. Set these to cover the main structural regions of the density map, while excluding noisy areas")
+parser.add_argument("ncores",help="Number of parallel processes to use")
+parser.add_argument("--chimerax", default = False, help="Path to ChimeraX if it cannot be determined automatically")
 
-negtive_laplacian_cutoff=float(sys.argv[7])
-positive_laplacian_cutoff=float(sys.argv[8])
+argument = parser.parse_args()
+
+domain_dir = argument.domain_dir
+map_dir = argument.map_dir
+fitout_dir = argument.fitout_dir
+ref_map_threshold = float(argument.ref_map_threshold)
+resolution = float(argument.resolution)
+n_search = int(argument.n_search)
+negtive_laplacian_cutoff = float(argument.negtive_laplacian_cutoff)
+positive_laplacian_cutoff = float(argument.positive_laplacian_cutoff)
+n_process=int(argument.ncores)
+if argument.chimerax:
+    ChimeraX = argument.chimerax
+
+if shutil.which(ChimeraX) is None:
+    raise ValueError('ChimeraX not found')
+
 fit_map_laplacian_cutoff_low=-2
 fit_map_laplacian_cutoff_high=15
 

--- a/DomainSeeker_CLI/fit_with_powerfit.py
+++ b/DomainSeeker_CLI/fit_with_powerfit.py
@@ -1,0 +1,69 @@
+import os
+
+import tqdm
+
+from powerfit_em.powerfit import setup_target, setup_template_structure, setup_rotational_matrix
+from powerfit_em.powerfitter import PowerFitter
+from powerfit_em.analyzer import Analyzer
+from powerfit_em.helpers import write_fits_to_pdb
+
+target_volume = 'em_data/A.mrc'
+resolution = 6.5
+no_resampling = True
+resampling_rate = 2
+no_trimming = False
+trimming_cutoff = None
+
+with open(target_volume, 'rb') as target_in:
+    target = setup_target(
+        target_in, 
+        resolution, 
+        no_resampling, 
+        resampling_rate, 
+        no_trimming, 
+        trimming_cutoff
+        )
+
+
+template_structure = 'domain/Q6X6Z7_D0.pdb'
+chain = None
+# target = target_volume
+# resolution =  
+core_weighted = False
+
+with open(template_structure, 'rb') as template_in:
+    structure, template, mask, z_sigma = setup_template_structure(
+        template_in, 
+        chain, 
+        target, 
+        resolution, 
+        core_weighted
+    )
+
+angle = 2
+
+rotmat = setup_rotational_matrix(angle)
+
+queue = None
+nproc = 10
+laplace = False
+
+pf = PowerFitter(target, rotmat, template, mask, queue, nproc, laplace=laplace)
+pf.scan(progress=tqdm.tqdm)
+
+
+analyzer = Analyzer(
+        pf.lcc,
+        rotmat,
+        pf.rot,
+        voxelspacing=target.voxelspacing,
+        origin=target.origin,
+        z_sigma=z_sigma,
+    )
+
+analyzer.tofile('correct.solutions')
+
+outputdir = 'powerfit_fits/'
+if not os.path.exists(outputdir):
+    os.mkdir(outputdir)
+write_fits_to_pdb(structure, analyzer.solutions[:10], basename=os.path.join(outputdir, "out"))

--- a/DomainSeeker_CLI/get_fitted_domains.py
+++ b/DomainSeeker_CLI/get_fitted_domains.py
@@ -32,15 +32,15 @@ def transform_save_single_fit(u,original_xyzs,transformation_matrix,save_path):
 os.makedirs(os.path.join(fitout_subdir,"fitted_domains"),exist_ok=True)
 
 for domain in domain_list:
-    domain_path=os.path.join(domain_dir,domain+'.pdb')
+    domain_base = "_".join(domain.split("_")[0:2])
+    fold = int(domain.split("_")[2])
+    domain_path=os.path.join(domain_dir,domain_base+'.pdb')
     u=mda.Universe(domain_path)
     original_xyzs=u.atoms.positions
 
-    log_path=os.path.join(fitout_subdir,"fitlogs",domain+'.log')
+    log_path=os.path.join(fitout_subdir,"fitlogs",domain_base+'.log')
     transformation_matrix_list=get_transformation_matrix_list(log_path)
 
-    n=len(transformation_matrix_list)
-    for i in range(n):
-        transformation_matrix=transformation_matrix_list[i]
-        save_path=os.path.join(fitout_subdir,"fitted_domains",f"{domain}_fit_{i:03d}.pdb")
-        transform_save_single_fit(u,original_xyzs,transformation_matrix,save_path)
+    transformation_matrix=transformation_matrix_list[fold]
+    save_path=os.path.join(fitout_subdir,"fitted_domains",f"{domain_base}_fit_{fold:03d}.pdb")
+    transform_save_single_fit(u,original_xyzs,transformation_matrix,save_path)

--- a/DomainSeeker_CLI/get_fitted_domains.py
+++ b/DomainSeeker_CLI/get_fitted_domains.py
@@ -1,11 +1,17 @@
+import os,argparse
 import MDAnalysis as mda
 import numpy as np
-import sys,os
 
-argv=sys.argv
-domain_dir=argv[1]
-fitout_subdir=argv[2]
-domain_list=argv[3:]    #without suffix
+parser = argparse.ArgumentParser(description="Create .pdb files of fitted domains")
+parser.add_argument("domain_dir")
+parser.add_argument("fitout_subdir", help="fitout_subdir is the subdirectory (e.g., 'A.mrc') of the fitout_dir")
+parser.add_argument("domain_list", nargs="+")
+argument = parser.parse_args()
+
+
+domain_dir=argument.domain_dir
+fitout_subdir=argument.fitout_subdir
+domain_list=argument.domain_list
 
 
 def get_transformation_matrix_list(log_path):

--- a/DomainSeeker_CLI/parse_with_pae.py
+++ b/DomainSeeker_CLI/parse_with_pae.py
@@ -1,33 +1,38 @@
+import os,sys,argparse
 import numpy as np
 import networkx as nx
 import MDAnalysis as mda
-import os,sys
 import multiprocessing
 from tqdm import tqdm
 import warnings
 
-pdb_dir=sys.argv[1]
-pae_dir=sys.argv[2]
-output_dir=sys.argv[3]
-n_processors=int(sys.argv[4])
+parser = argparse.ArgumentParser(description="Perform domain partitioning based on the PAE information",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("pdb_dir")
+parser.add_argument("pae_dir")
+parser.add_argument("output_dir")
+parser.add_argument("--plddt_cutoff", default = 70, help="Residues with a pLDDT value above this threshold are included as nodes in the residue graph. Residues falling below the threshold are considered to have low prediction confidence and are excluded.")
+parser.add_argument("--pae_cutoff", default = 5, help="An edge is established between two residues if their average PAE exceeds this value.")
+parser.add_argument("--clique_cutoff", default = 4, help="Cliques containing at least this number of residues are treated as nodes in the cluster network; those smaller than the threshold are filtered out")
+parser.add_argument("--min_dege_ratio_between_cliques", default = 0.6, help="In the residue network, two cliques are connected in the cluster network if they share at least min_common_nodes_ratio residues, or if the edge between them reaches min_edge_ratio. Connected cliques collectively form a domain.")
+parser.add_argument("--min_common_nodes_ratio_between_cliques", default = 0.5, help="In the residue network, two cliques are connected in the cluster network if they share at least min_common_nodes_ratio residues, or if the edge between them reaches min_edge_ratio. Connected cliques collectively form a domain.")
+parser.add_argument("--minimum_domain_length", default = 40, help="Domains containing fewer than this number of residues are filtered out.")
+parser.add_argument("--maximum_domain_length", default = 1000, help="Domains containing more than this number of residues are filtered out.")
+parser.add_argument("--n_processors", default = 10, help="Number of parallel processes to use")
+argument = parser.parse_args()
 
-#parameters
-if len(sys.argv)>5:
-    plddt_cutoff=float(sys.argv[5])
-    pae_cutoff=float(sys.argv[6])
-    clique_cutoff=int(sys.argv[7])
-    min_dege_ratio_between_cliques=float(sys.argv[8])
-    min_common_nodes_ratio_between_cliques=float(sys.argv[9])
-    minimum_domain_length=int(sys.argv[10])
-    maximum_domain_length=int(sys.argv[11])
-else:
-    plddt_cutoff=70 
-    pae_cutoff=5
-    clique_cutoff=4
-    min_dege_ratio_between_cliques=0.6
-    min_common_nodes_ratio_between_cliques=0.5
-    minimum_domain_length=40
-    maximum_domain_length=1000
+pdb_dir=argument.pdb_dir
+pae_dir=argument.pae_dir
+output_dir=argument.output_dir
+n_processors=int(argument.n_processors)
+plddt_cutoff=float(argument.plddt_cutoff)
+pae_cutoff=float(argument.pae_cutoff)
+clique_cutoff=int(argument.clique_cutoff)
+min_dege_ratio_between_cliques=float(argument.min_dege_ratio_between_cliques)
+min_common_nodes_ratio_between_cliques=float(argument.min_common_nodes_ratio_between_cliques)
+minimum_domain_length=int(argument.minimum_domain_length)
+maximum_domain_length=int(argument.maximum_domain_length)
+
 
 
 def parse_pae_file(pae_json_file):

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The following image displays the user interface and configurable parameters of t
 
 > **box_num**: When calculating z-scores, data points are partitioned into a grid of box_num² cells based on their overlap volume and correlation values.  
 > **relative_density_cutoff**: Relative density is defined as the ratio of the number of data points in a grid cell to the average number of data points across all cells. Only cells with a relative density above this threshold are used when calculating the average curve, to minimize the influence of anomalies.  
-> **min_data_per_box**: After filtering cells by relative density, cells within the same overlap volume range are grouped into *box_num* bins. Each bin must contain at least *min_data_per_box* data points; otherwise, it is merged with an adjacent bin. The mean and standard deviation of the correlation values are computed for each bin to derive an interpolation function across overlap volumes.
+> **min_data_per_box**: After filtering cells by relative density, cells within the same overlap volume range are grouped into *box_num* bins. Each bin must contain at least *min_data_per_box* data points; otherwise, it is merged with an adjacent bin. The mean and standard deviation of the correlation values are computed for each bin to derive an interpolation function across overlap volumes.  
 > **zScore_offset**: The z-score is converted to a probability using a sigmoid function: `Sigmoid(zScore – offset)`.  
 
 The output files generated from the prior calculation are shown in the image below:  


### PR DESCRIPTION
# argparse
I was using the CLI version of DomainSeeker and  would like to improve on the usage of sys.argv for argument parsing. Usage of argparse allows to get helping information in the terminal with the `-h` option and gives better feedback on missing arguments. I copied help information from the README file. For the scripts `parse_with_pae.py` and `calculate_prior_probabilities.py` I added default values based on the README file. The scripts ran well with the example data you provided.

# get_fitted_domain
In the current state, `get_fitted_domain.py` returns .pdb files for all the fits of a specified domain. However, for larger proteins and a larger number of prey proteins, this may amount to a great number of structures. In addition, this accumulation of PDBs may contain suboptimal fits, though the quality of fits may already be known from the prior/posterior probabilites.

In commit `9fd43139818e55cf51d2b4bc48ffe1a4c970b27c` I changed the for loop to only create .pdb files for specified fits. A call to `get_fitted_domain` would thus look like
```
python get_fitted_domains.py domains/ fitout/A.mrc/ E9Q9B7_D4_0 E9Q9B7_D2_59
```
and would create only two .pdb files. The fits of interest would then come from prior/posterior probabilites or other reported scores.